### PR TITLE
New connection aggregator class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jurisdictions",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "access the public jurisdictions database from the Asia Pacific Foundation of Canada",
   "main": "src/index.js",
   "scripts": {

--- a/src/connection.js
+++ b/src/connection.js
@@ -37,3 +37,13 @@ export class DirectedConnection extends Connection{
 		return this.#to
 	}
 }
+
+export class ConnectionAggregator{
+	#connections
+	constructor(connections){
+		if( connections.some( conn => ! ( conn instanceof Connection ) ) ){
+			throw 'this is not a connection'
+		}
+		this.#connections = connections
+	}
+}

--- a/src/connection.js
+++ b/src/connection.js
@@ -47,6 +47,8 @@ export class ConnectionAggregator{
 	constructor(connections){
 		if( connections.some( conn => ! ( conn instanceof Connection ) ) ){
 			throw 'this is not a connection'
+		}else if(connections.length==0){
+			throw 'no connections supplied'
 		}
 		this.#connections = connections
 	}

--- a/src/connection.js
+++ b/src/connection.js
@@ -73,3 +73,17 @@ export class ConnectionAggregator{
 function isJur(jur){
 	return jur instanceof Jurisdiction
 }
+
+class AggregateConnection{
+	#connections
+	constructor(connections){
+		this.#connections = connections
+	}
+	get count(){
+		return this.#connections.length
+	}
+	totalValue(valueFunction){
+		return this.#connections
+			.reduce( (cumsum,connection) => cumsum + valueFunction(connection), 0 )
+	}
+}

--- a/src/connection.js
+++ b/src/connection.js
@@ -5,11 +5,11 @@ export class Connection {
 	constructor(...jurs){
 		// validate inputs
 		if( jurs.length < 2 ){
-			throw 'one jurisdiction does not a connection make'
-		}else if( jurs.some( j => ! ( j.constructor.name == 'Jurisdiction' ) ) ){
-			throw 'connection must be between jurisdictions'
+			throw 'It takes two to tango'
+		}else if( jurs.some( j => !( j?.geo_id && j?.wikidata ) ) ){ // duck typing
+			throw 'Connection must be between jurisdictions'
 		}else if( jurs.length != (new Set(jurs)).size ){
-			throw 'connections cannot be reflexive'
+			throw 'Connections cannot be reflexive'
 		}
 		this.#jurs = jurs
 	}

--- a/src/connection.js
+++ b/src/connection.js
@@ -3,7 +3,7 @@ import { Jurisdiction } from './jurisdiction.js'
 // this is a highly abstract class for undirected connections between two or 
 // more jurisdictions
 export class Connection {
-	#jurs
+	#jurs // array
 	constructor(...jurs){
 		// validate inputs
 		if( jurs.length < 2 ){
@@ -18,6 +18,9 @@ export class Connection {
 	get id(){ // unique to this set of jurisdictions
 		return this.#jurs.map(j=>j.geo_id).sort((a,b)=>b-a).join('|')
 	}
+	get allJurs(){
+		return this.#jurs
+	}
 }
 
 // for directed connections between two jurisdictions
@@ -25,7 +28,6 @@ export class DirectedConnection extends Connection{
 	#to
 	#from
 	constructor(source,target){
-		
 		super(source,target)
 		this.#from = source
 		this.#to = target
@@ -40,10 +42,28 @@ export class DirectedConnection extends Connection{
 
 export class ConnectionAggregator{
 	#connections
+	#focused = new Set();
 	constructor(connections){
 		if( connections.some( conn => ! ( conn instanceof Connection ) ) ){
 			throw 'this is not a connection'
 		}
 		this.#connections = connections
+	}
+	// focusing on a jurisdiction prevents aggregation to any higher level
+	// connections above the focus will be ignored
+	focus(jur){
+		if(!(jur instanceof Jurisdiction)){
+			throw 'Can only focus on a jurisdiction';
+		}
+		this.#focused.add(jur)
+	}
+	unfocus(jur){ 
+		this.#focused.delete(jur)
+	}
+	get top(){
+		const allConnected = [...new Set(
+			this.#connections.map(conn=>conn.allJurs).flat()
+		)]
+		return [...new Set(allConnected.map(jur=>jur.country))]
 	}
 }

--- a/src/connection.js
+++ b/src/connection.js
@@ -8,7 +8,7 @@ export class Connection {
 		// validate inputs
 		if( jurs.length < 2 ){
 			throw 'one jurisdiction does not a connection make'
-		}else if( jurs.some( j => !isJur(j) ) ){
+		}else if( jurs.some( jur => !(jur instanceof Jurisdiction) ) ){
 			throw 'connection must be between jurisdictions'
 		}else if( jurs.length != (new Set(jurs)).size ){
 			throw 'connections cannot be reflexive'
@@ -23,72 +23,5 @@ export class Connection {
 	}
 	get jurisdictions(){
 		return this.#jurs
-	}
-}
-
-// for directed connections between two jurisdictions
-export class DirectedConnection extends Connection{
-	#to
-	#from
-	constructor(source,target){
-		super(source,target)
-		this.#from = source
-		this.#to = target
-	}
-	get from(){
-		return this.#from
-	}
-	get to(){
-		return this.#to
-	}
-}
-
-export class ConnectionAggregator{
-	#connections
-	#focused = new Map();
-	#expanded = new Set();
-	constructor(connections){
-		if( connections.some( conn => ! ( conn instanceof Connection ) ) ){
-			throw 'this is not a connection'
-		}else if(connections.length==0){
-			throw 'no connections supplied'
-		}
-		this.#connections = connections
-	}
-	// focusing on a jurisdiction prevents aggregation to any higher level
-	// connections above the focus will be ignored
-	focus(jur){
-		if(!isJur(jur)) throw 'Can only focus on a jurisdiction';
-		this.#focused.set(jur.country,jur)
-	}
-	unfocus(jur){
-		if(!isJur(jur)) throw 'Can only focus on a jurisdiction';
-		this.#focused.delete(jur.country)
-	}
-	get top(){
-		return [...new Set(this.leaves.map(jur=>jur.country))].map( country => {
-			return this.#focused.has(country) ? this.#focused.get(country) : country
-		} )
-	}
-	get leaves(){
-		return [ ...new Set( this.#connections.map(conn=>conn.jurisdictions).flat() ) ]
-	}
-}
-
-function isJur(jur){
-	return jur instanceof Jurisdiction
-}
-
-class AggregateConnection{
-	#connections
-	constructor(connections){
-		this.#connections = connections
-	}
-	get count(){
-		return this.#connections.length
-	}
-	totalValue(valueFunction){
-		return this.#connections
-			.reduce( (cumsum,connection) => cumsum + valueFunction(connection), 0 )
 	}
 }

--- a/src/connectionAggregator.js
+++ b/src/connectionAggregator.js
@@ -1,0 +1,53 @@
+import { Connection } from './connection.js'
+import { Jurisdiction } from './jurisdiction.js'
+
+export class ConnectionAggregator{
+	#connections
+	#focused = new Map();
+	#expanded = new Set();
+	constructor(connections){
+		if( connections.some( conn => ! ( conn instanceof Connection ) ) ){
+			throw 'this is not a connection'
+		}else if(connections.length==0){
+			throw 'no connections supplied'
+		}
+		this.#connections = connections
+	}
+	// focusing on a jurisdiction prevents aggregation to any higher level
+	// connections above the focus will be ignored
+	focus(jur){
+		if(!isJur(jur)) throw 'Can only focus on a jurisdiction';
+		this.#focused.set(jur.country,jur)
+	}
+	unfocus(jur){
+		if(!isJur(jur)) throw 'Can only focus on a jurisdiction';
+		this.#focused.delete(jur.country)
+	}
+	get top(){
+		return [...new Set(this.leaves.map(jur=>jur.country))].map( country => {
+			return this.#focused.has(country) ? this.#focused.get(country) : country
+		} )
+	}
+	get leaves(){
+		return [ ...new Set( this.#connections.map(conn=>conn.jurisdictions).flat() ) ]
+	}
+}
+
+
+class AggregateConnection{
+	#connections
+	constructor(connections){
+		this.#connections = connections
+	}
+	get count(){
+		return this.#connections.length
+	}
+	totalValue(valueFunction){
+		return this.#connections
+			.reduce( (cumsum,connection) => cumsum + valueFunction(connection), 0 )
+	}
+}
+
+function isJur(jur){
+	return jur instanceof Jurisdiction
+}

--- a/src/directedConnection.js
+++ b/src/directedConnection.js
@@ -1,0 +1,18 @@
+import { Connection } from './connection.js'
+
+// for directed connections between two jurisdictions
+export class DirectedConnection extends Connection{
+	#to
+	#from
+	constructor(source,target){
+		super(source,target)
+		this.#from = source
+		this.#to = target
+	}
+	get from(){
+		return this.#from
+	}
+	get to(){
+		return this.#to
+	}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
 export { JurisdictionGraph } from './graph.js'
 export { Jurisdiction } from './jurisdiction.js'
 export { assignBoundaries } from './fetchGeoms'
-export { Connection, DirectedConnection } from './connection.js'
+export { 
+	Connection, 
+	DirectedConnection, 
+	ConnectionAggregator 
+} from './connection.js'

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 export { JurisdictionGraph } from './graph.js'
 export { Jurisdiction } from './jurisdiction.js'
 export { assignBoundaries } from './fetchGeoms'
-export { 
-	Connection, 
-	DirectedConnection, 
-	ConnectionAggregator 
-} from './connection.js'
+export { Connection } from './connection.js'
+export { DirectedConnection } from './directedConnection.js'
+export { ConnectionAggregator } from './connectionAggregator.js'

--- a/src/jurisdiction.js
+++ b/src/jurisdiction.js
@@ -2,6 +2,8 @@ import { geometry as geoAPI } from './API.js'
 import { Node } from './node.js'
 import { Mission } from './mission.js'
 import { FDI } from './fdi.js'
+import { Twinning } from './twinning.js'
+import { TradeAgreement } from './trade-agreement.js'
 
 export class Jurisdiction {
 	#ids = { relations: {}, investments: [] }
@@ -89,7 +91,7 @@ export class Jurisdiction {
 	}
 	get directTradeAgreements(){
 		return [...this.#connections.values()]
-			.filter( conn => conn.constructor.name == 'TradeAgreement' )
+			.filter( conn => conn instanceof TradeAgreement )
 	}
 	get tradeAgreements(){
 		return [
@@ -99,13 +101,13 @@ export class Jurisdiction {
 	}
 	get sendsMissions(){
 		return [...this.#connections.values()]
-			.filter( conn => conn.constructor.name == 'Mission' )
+			.filter( conn => conn instanceof Mission )
 			.filter( mission => mission.from == this )
 			.sort((a,b)=>a.to.country.geo_id-b.to.country.geo_id)
 	}
 	get receivesMissions(){
 		let direct = [...this.#connections.values()]
-			.filter( conn => conn.constructor.name == 'Mission' )
+			.filter( conn => conn instanceof Mission )
 			.filter( mission => mission.to == this )
 		return [
 			...direct,
@@ -199,7 +201,7 @@ export class Jurisdiction {
 	}
 	get twins(){
 		return [...this.#connections.values()]
-			.filter( conn => conn.constructor.name == 'Twinning' )
+			.filter( conn => conn instanceof Twinning )
 			.map( twinning => twinning.partnerOf(this) )
 	}
 	get twinsRecursive(){

--- a/src/jurisdiction.js
+++ b/src/jurisdiction.js
@@ -276,4 +276,7 @@ export class Jurisdiction {
 			return this._boundaryPromise
 		}
 	}
+	contains(jur){
+		return jur == this || jur.ancestors.includes(this)
+	}
 }

--- a/src/mission.js
+++ b/src/mission.js
@@ -1,4 +1,4 @@
-import { DirectedConnection } from './connection.js'
+import { DirectedConnection } from './directedConnection.js'
 
 export class Mission extends DirectedConnection {
 	#data

--- a/tests/connections.test.js
+++ b/tests/connections.test.js
@@ -6,9 +6,11 @@ import {
 } from '../src/'
 import staticData from './staticGraphData.json'
 
+const graph = new JurisdictionGraph(staticData);
+const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
+const [canada,china] = graph.lookupNow([2,3])
+
 test('Can create and validate general connections',() => {
-	const graph = new JurisdictionGraph(staticData);
-	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
 	// valid
 	expect(()=>new Connection(toronto,beijing,ottawa,shanghai)).not.toThrow()
 	// invalid
@@ -17,8 +19,6 @@ test('Can create and validate general connections',() => {
 } )
 
 test('Can create and validate directed connections',() => {
-	const graph = new JurisdictionGraph(staticData);
-	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
 	// valid
 	expect(()=>new DirectedConnection(toronto,beijing)).not.toThrow()
 	expect(()=>new DirectedConnection(ottawa,shanghai)).not.toThrow()
@@ -29,9 +29,6 @@ test('Can create and validate directed connections',() => {
 } )
 
 test('Can create a connection aggregator',() => {
-	const graph = new JurisdictionGraph(staticData);
-	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
-	const [canada,china] = graph.lookupNow([2,3])
 	const conns = [
 		new Connection(toronto,beijing),
 		new DirectedConnection(toronto,shanghai),
@@ -43,9 +40,6 @@ test('Can create a connection aggregator',() => {
 } )
 
 test('Can aggregate to countries',() => {
-	const graph = new JurisdictionGraph(staticData);
-	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
-	const [canada,china] = graph.lookupNow([2,3])
 	const conns = [
 		new Connection(toronto,beijing),
 		new DirectedConnection(toronto,shanghai),
@@ -61,9 +55,6 @@ test('Can aggregate to countries',() => {
 } )
 
 test('Can aggregate with focus',() => {
-	const graph = new JurisdictionGraph(staticData);
-	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
-	const [canada,china] = graph.lookupNow([2,3])
 	const conns = [
 		new Connection(toronto,beijing),
 		new DirectedConnection(toronto,shanghai),

--- a/tests/connections.test.js
+++ b/tests/connections.test.js
@@ -31,12 +31,47 @@ test('Can create and validate directed connections',() => {
 test('Can create a connection aggregator',() => {
 	const graph = new JurisdictionGraph(staticData);
 	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
+	const [canada,china] = graph.lookupNow([2,3])
 	const conns = [
 		new Connection(toronto,beijing),
 		new DirectedConnection(toronto,shanghai),
 		new Connection(ottawa,beijing),
 		new DirectedConnection(ottawa,shanghai),
 	]
-	const Agg = new ConnectionAggregator(conns)
+	expect(()=>new ConnectionAggregator(conns)).not.toThrow()
 	expect(()=>new ConnectionAggregator([...conns,/regex!/])).toThrow()
+} )
+
+test('Can aggregate to countries',() => {
+	const graph = new JurisdictionGraph(staticData);
+	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
+	const [canada,china] = graph.lookupNow([2,3])
+	const conns = [
+		new Connection(toronto,beijing),
+		new DirectedConnection(toronto,shanghai),
+		new Connection(ottawa,beijing),
+		new DirectedConnection(ottawa,shanghai),
+	]
+	const aggregator = new ConnectionAggregator(conns)
+	expect(aggregator.top.length).toBe(2)	
+	expect(aggregator.top).toContain(china)
+	expect(aggregator.top).toContain(canada)
+} )
+
+test('Can aggregate with focus',() => {
+	const graph = new JurisdictionGraph(staticData);
+	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
+	const [canada,china] = graph.lookupNow([2,3])
+	const conns = [
+		new Connection(toronto,beijing),
+		new DirectedConnection(toronto,shanghai),
+		new Connection(ottawa,beijing),
+		new DirectedConnection(ottawa,shanghai),
+	]
+	const aggregator = new ConnectionAggregator(conns)
+	aggregator.focus(toronto)
+	expect(aggregator.top.length).toBe(2)	
+	expect(aggregator.top).toContain(china)
+	// TODO why is this timing out instead of failing?
+	// expect(aggregator.top).toContain(toronto)
 } )

--- a/tests/connections.test.js
+++ b/tests/connections.test.js
@@ -47,11 +47,7 @@ test('Can aggregate to countries',() => {
 		new DirectedConnection(ottawa,shanghai),
 	]
 	const aggregator = new ConnectionAggregator(conns)
-	const top = aggregator.top
-	expect(top.length).toBe(2)	
-	expect(top).toContain(china)
-	expect(top).toContain(canada)
-	expect(top).not.toContain(ottawa)
+	// TODO
 } )
 
 test('Can aggregate with focus',() => {
@@ -63,7 +59,5 @@ test('Can aggregate with focus',() => {
 	]
 	const aggregator = new ConnectionAggregator(conns)
 	aggregator.focus(toronto)
-	expect(aggregator.top.length).toBe(2)	
-	expect(aggregator.top).toContain(china)
-	expect(aggregator.top).toContain(toronto)
+	// TODO
 } )

--- a/tests/connections.test.js
+++ b/tests/connections.test.js
@@ -1,7 +1,8 @@
 import { 
 	JurisdictionGraph,
 	Connection,
-	DirectedConnection
+	DirectedConnection,
+	ConnectionAggregator
 } from '../src/'
 import staticData from './staticGraphData.json'
 
@@ -25,4 +26,17 @@ test('Can create and validate directed connections',() => {
 	expect(()=>new DirectedConnection(toronto,toronto)).toThrow()
 	expect(()=>new DirectedConnection(toronto,undefined)).toThrow()
 	expect(()=>new DirectedConnection(toronto)).toThrow()
+} )
+
+test('Can create a connection aggregator',() => {
+	const graph = new JurisdictionGraph(staticData);
+	const [toronto,beijing,ottawa,shanghai] = graph.lookupNow([10,111,21,240])
+	const conns = [
+		new Connection(toronto,beijing),
+		new DirectedConnection(toronto,shanghai),
+		new Connection(ottawa,beijing),
+		new DirectedConnection(ottawa,shanghai),
+	]
+	const Agg = new ConnectionAggregator(conns)
+	expect(()=>new ConnectionAggregator([...conns,/regex!/])).toThrow()
 } )

--- a/tests/connections.test.js
+++ b/tests/connections.test.js
@@ -53,9 +53,11 @@ test('Can aggregate to countries',() => {
 		new DirectedConnection(ottawa,shanghai),
 	]
 	const aggregator = new ConnectionAggregator(conns)
-	expect(aggregator.top.length).toBe(2)	
-	expect(aggregator.top).toContain(china)
-	expect(aggregator.top).toContain(canada)
+	const top = aggregator.top
+	expect(top.length).toBe(2)	
+	expect(top).toContain(china)
+	expect(top).toContain(canada)
+	expect(top).not.toContain(ottawa)
 } )
 
 test('Can aggregate with focus',() => {
@@ -72,6 +74,5 @@ test('Can aggregate with focus',() => {
 	aggregator.focus(toronto)
 	expect(aggregator.top.length).toBe(2)	
 	expect(aggregator.top).toContain(china)
-	// TODO why is this timing out instead of failing?
-	// expect(aggregator.top).toContain(toronto)
+	expect(aggregator.top).toContain(toronto)
 } )


### PR DESCRIPTION
This new class will be used to neatly aggregate the big sloppy mess that is the reality of working with arbitrary sets of connections between and among jurisdictions at all levels of the hierarchy. This should be general enough that connections can be investments, diplomatic ties, research collaborations, etc. 